### PR TITLE
Revert "[REF] runbot_travis2docker: Change external dependencies from…

### DIFF
--- a/runbot_travis2docker/__openerp__.py
+++ b/runbot_travis2docker/__openerp__.py
@@ -14,10 +14,8 @@
         "runbot",
     ],
     "external_dependencies": {
-        "python": [
-            'travis2docker',
-            'docker',
-        ],
+        "python": ['travis2docker'],
+        "bin": ['docker'],
     },
     "data": [
         "views/runbot_repo_view.xml",


### PR DESCRIPTION
Reverts Vauxoo/runbot-addons#29

There are many fails in production by this PR:
- Build killed in job_10 or job_20
- Build never running in job_30
