### PR TITLE
[REF] runbot_travis2docker: Add start ssh and add port 22

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -104,7 +104,9 @@ class RunbotBuild(models.Model):
             '-e', 'TRAVIS_BRANCH=' + branch_base,
             '-e', 'RUNBOT=1',
             '-e', 'UNBUFFER=1',
+            '-e', 'START_SSH=1',
             '-p', '%d:%d' % (build.port, 8069),
+            '-p', '%d:%d' % (build.port + 1, 22),
         ] + pr_cmd_env + [
             '--name=' + build.docker_container, '-t',
             build.docker_image,


### PR DESCRIPTION
- Add feature to connect to runbot from ssh using `autorized_keys` of runbot OS user.
