### PR TITLE
[FIX] runbot_send_email: Add missing runbot Warning status

### DIFF
--- a/runbot_send_email/data/runbot_send_email_data.xml
+++ b/runbot_send_email/data/runbot_send_email_data.xml
@@ -88,6 +88,37 @@ Build #${object.sequence} is ${object.state}
           </table>
         </div>
     </div>
+% elif (object.state=="running" or object.state=="done") and (object.result=="warn"):
+    <div style="border-radius:5px;padding:0px;width:570px;font-size:13px">
+        <div>
+          <table style="padding:0px;border:0px;width:100%;border-spacing:0">
+            <thead>
+              <tr style="padding:0px;border:0px;font-weight:700;font-size:18px;background-color:#fbfddc;color:#99944b">
+                <td style="padding:0px;border:0px;padding:0px 20px 0px 0px;vertical-align:middle;border-top:1px solid #808080;border-bottom:1px solid #adadad;width:50px;padding:0px;text-align:center;vertical-align:middle;padding-top:5px;border-left:1px solid #606060;border-top-left-radius:5px"><div style="width:25px;min-height:30px;margin-left:15px;margin-top:0px;vertical-align:middle"><img class="CToWUd" src="http://fa2png.io/media/icons/ion-alert-circled/25/0/99944b_none.png" height="25" width="25"></div></td>
+                <td style="padding:0px;border:0px;padding:0px 20px 10px 0px;vertical-align:middle;border-top:1px solid #808080;border-bottom:1px solid #adadad">
+                    <span style="display:inline-block;margin-top:12px;vertical-align:middle"><a href="${object.log_link}" style="text-decoration:underline;text-decoration:none;font-weight:bold;color:#57769d;text-decoration:underline;color:#99944b" target="_blank">
+Build #${object.sequence} is ${object.state} but with warnings
+</a></span>
+</td>
+                <td style="padding:0px;border:0px;font-weight:normal;font-size:12px;vertical-align:middle;padding:0px 20px 0px 0px;vertical-align:middle;border-top:1px solid #808080;border-bottom:1px solid #adadad;border-right:1px solid #606060;border-top-right-radius:5px" align="right">
+                    <div style="vertical-align:middle;min-height:20px;width:20px;padding:20px;display:inline-block;width:20px;min-height:20px"></div> <span style="vertical-align:middle">Age: ${object.job_age}m</span>
+</td>
+   </tr>
+      </thead>
+            <tbody style="margin-bottom:40px">
+              <tr style="padding:0px;border:0px">
+                <td style="padding:0px;border:0px;padding:10px 20px 10px 0px;height:20px;width:20px;padding:0px;border-left:1px solid #adadad;padding-top:20px;padding-bottom:5px;text-align:center"></td>
+                <td style="padding:0px;border:0px;color:#808080;padding:10px 20px 10px 0px;height:20px;padding-top:20px;padding-bottom:5px"><strong>${object.committer}</strong></td>
+                <td style="padding:0px;border:0px;color:#808080;padding:10px 20px 10px 0px;height:20px;border-right:1px solid #adadad;padding-top:20px;padding-bottom:5px;font-size:12px" align="right">changeset <a href="${object.commit_link}" style="text-decoration:underline;color:#606060" target="_blank">${object.name[:8]}</a></td>
+              </tr>
+              <tr style="padding:0px;border:0px">
+                <td style="padding:0px;border:0px;padding:10px 20px 10px 0px;height:20px;width:20px;padding:0px;border-left:1px solid #adadad;border-bottom-left-radius:5px;border-bottom:1px solid #adadad">&nbsp;</td>
+                <td colspan="2" style="padding:0px;border:0px;color:#808080;padding:10px 20px 10px 0px;height:20px;border-right:1px solid #adadad;padding-bottom:20px;padding-top:0px;border-bottom:1px solid #adadad;border-bottom-right-radius:5px">${object.subject}</td>
+              </tr>
+              </tbody>
+          </table>
+        </div>
+    </div>
 % else:
     <div style="border-radius:5px;padding:0px;width:570px;font-size:13px">
         <div>
@@ -138,6 +169,16 @@ Build #${object.sequence} is ${object.state} but failed
           <b>System message:</b>
           <p style="margin-top:5px;margin-bottom:0px">
               Your Build is ${object.state} and runbot test completed successfully.
+              <br/>Thanks for your patience.
+          </p>
+        </span>
+    </div>
+% elif (object.state=="running" or object.state=="done") and (object.result=="warn"):
+      <div style="width:528px;padding:10px 20px;border:1px solid #adadad;border-radius:5px;font-size:12px;margin-bottom:0px;background-color:#fbfddc;margin-top:20px">
+        <span style="color:#808080">
+          <b>System message:</b>
+          <p style="margin-top:5px;margin-bottom:0px">
+              Your Build is ${object.state} and runbot test completed with warnings. Please read the runbot logs and check.
               <br/>Thanks for your patience.
           </p>
         </span>

--- a/runbot_send_email/models/runbot_build.py
+++ b/runbot_send_email/models/runbot_build.py
@@ -77,6 +77,8 @@ class RunbotBuild(models.Model):
             elif record.state in ('running', 'done'):
                 if record.result == 'ok':
                     status = 'Fixed'
+                elif record.result == 'warn':
+                    status = "Warning"
             record.status_build = status
 
     @api.multi

--- a/runbot_send_email/tests/test_runbot_send_email.py
+++ b/runbot_send_email/tests/test_runbot_send_email.py
@@ -107,6 +107,11 @@ class TestRunbotSendEmail(TransactionCase):
         self.build.write({'result': 'ko'})
         self.build.github_status()
 
+    def test_30_send_email_result_warn(self):
+        self.build = self.build.search(self.domain)
+        self.build.write({'result': 'warn', 'state': 'done'})
+        self.build.github_status()
+
     def test_40_send_email_state_testing(self):
         self.build = self.build.search(self.domain)
         self.build.write({'state': 'testing'})


### PR DESCRIPTION
Fixed - Receiving red alerts (fails) when runbot results in yellow (warnings) and logs give me a Success (green)
https://github.com/Vauxoo/runbot-addons/issues/75

![warning_send_email](https://cloud.githubusercontent.com/assets/16093067/14401756/d68a0e10-fde6-11e5-8374-789d9be9bba6.png)
