### PR TITLE
[IMP] runbot_travis2docker: Open url to pre-generate routing map

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -7,8 +7,10 @@ import logging
 import os
 import requests
 import subprocess
+import threading
 import time
 import traceback
+import urllib2
 
 import openerp
 from openerp import fields, models, api
@@ -403,4 +405,8 @@ class RunbotBuild(models.Model):
                      build.docker_container,
                      "bash", "-c", "echo '%(keys)s' | tee -a '%(dir)s'" % dict(
                         keys=ssh_keys, dir="/home/odoo/.ssh/authorized_keys")])
+            url = build.branch_id._get_branch_quickconnect_url(
+                build.domain, build.dest)[build.branch_id.id]
+            urlopen_t = threading.Thread(target=urllib2.urlopen, args=(url,))
+            urlopen_t.start()
         return res


### PR DESCRIPTION
Related https://github.com/OCA/runbot-addons/issues/122


Steps to reproduce it
===============

 - We have a [build runbot instance](https://runbot.odoo-community.org/runbot/build/3284913) with the following [running log](https://runbot1.odoo-community.org/runbot/static/build/3284913-10-0-d09a11/logs/job_30_run.txt)
```txt
...
2017-03-29 17:29:56,473 167 INFO openerp_test odoo.modules.loading: Modules loaded.
...
```

Opening first time the url of the instance and second one using `time python -c "import urllib;urllib.urlopen('http://3284913-10-0-d09a11.runbot1.odoo-community.org/?db=3284913-10-0-d09a11-all')"` the result is:
![screen shot 2017-03-29 at 6 30 26 pm](https://cloud.githubusercontent.com/assets/6644187/24482210/d2e24790-14ac-11e7-8966-09bae31b2130.png)

The log affected was:
```txt
...
2017-03-30 00:21:40,762 167 INFO ? odoo.http: HTTP Configuring static files
2017-03-30 00:21:40,768 167 INFO openerp_test odoo.addons.base.ir.ir_http: Generating routing map
2017-03-30 00:21:43,674 167 INFO openerp_test werkzeug: 172.17.42.1 - - [30/Mar/2017 00:21:43] "GET /?db=3284913-10-0-d09a11-all HTTP/1.0" 200 -
2017-03-30 00:21:47,414 167 INFO openerp_test werkzeug: 172.17.42.1 - - [30/Mar/2017 00:21:47] "GET /?db=3284913-10-0-d09a11-all HTTP/1.0" 200 -
```

Saw
===
Log output  time spent 3 seconds `from 00:21:43 to 00:21:47`
Opening url time spent 4.5 seconds first time
Opening url time spent 0.8 seconds second time

Expected
=======
Open url time 4.5 seconds for first time connection for real user.

I mean, we could add a open url simulation from runbot after up build instance from runbot to improvement usability.