### PR TITLE
[REF] runbot_travis2docker: Ignore raise for github response

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -371,7 +371,7 @@ class RunbotBuild(models.Model):
 
     def get_ssh_keys(self, cr, uid, build, context=None):
         response = build.repo_id.github(
-            "/repos/:owner/:repo/commits/%s" % build.name)
+            "/repos/:owner/:repo/commits/%s" % build.name, ignore_errors=True)
         if not response:
             return
         keys = ""


### PR DESCRIPTION
Ignore a raise if committer user is not found from github.