### PR TITLE
[FIX] runbot_travis2docker: Avoid request if the token and url is equal

### DIFF
--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -71,12 +71,10 @@ class RunbotBranch(models.Model):
                 components = response.json()
                 updated_branch = None
                 for component in components['results']:
-                    if (updated_branch and
-                            updated_branch == component['branch']):
-                        continue
-                    if component['branch'] != branch['branch_name']:
-                        continue
-                    if project['name'] != branch.name_weblate:
+                    if ((updated_branch and
+                            updated_branch == component['branch']) or
+                            (component['branch'] != branch['branch_name']) or
+                            (project['name'] != branch.name_weblate)):
                         continue
                     has_build = self.env['runbot.build'].search(
                         [('branch_id', '=', branch.id),

--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -5,10 +5,45 @@
 
 import re
 
-import requests
 import subprocess
+import requests
 
 from openerp import fields, models, api
+
+
+def read_group(branch):
+    """Search all weblate API, project and component information.
+    Store into the local variable 'read_group.projects' to use as cache"""
+    if 'projects' not in read_group.__dict__:
+        read_group.projects = {}
+    url = branch.repo_id.weblate_url
+    key = '%s__%s' % (url, branch.repo_id.weblate_token)
+    page = 1
+    projects = []
+    session = requests.Session()
+    session.headers.update({
+        'Accept': 'application/json',
+        'User-Agent': 'runbot_travis2docker',
+        'Authorization': 'Token %s' % branch.repo_id.weblate_token
+    })
+    if key not in read_group.projects:
+        read_group.projects[key] = []
+        while True:
+            response = session.get('%s/projects/?page=%s' % (url, page))
+            response.raise_for_status()
+            data = response.json()
+            projects.extend(data['results'])
+            if not data['next']:
+                break
+            page += 1
+        for project in projects:
+            response = session.get('%s/projects/%s/components'
+                                   % (url, project['slug']))
+            response.raise_for_status()
+            data = response.json()
+            project['components'] = data['results']
+            read_group.projects[key].append(project)
+    return read_group.projects[key]
 
 
 class RunbotBranch(models.Model):
@@ -35,42 +70,15 @@ class RunbotBranch(models.Model):
 
     @api.model
     def cron_weblate(self):
-        projects = []
-        wl_token = ''
-        wl_url = ''
         for branch in self.search([('uses_weblate', '=', True)]):
             if (not branch.repo_id.weblate_token or
                     not branch.repo_id.weblate_url):
                 continue
             cmd = ['git', '--git-dir=%s' % branch.repo_id.path]
-            url = branch.repo_id.weblate_url
-            session = requests.Session()
-            session.headers.update({
-                'Accept': 'application/json',
-                'User-Agent': 'runbot_travis2docker',
-                'Authorization': 'Token %s' % branch.repo_id.weblate_token
-            })
-            if (wl_token != branch.repo_id.weblate_token or
-                    wl_url != branch.repo_id.weblate_url):
-                page = 1
-                while True:
-                    response = session.get('%s/projects/?page=%s' % (url,
-                                                                     page))
-                    response.raise_for_status()
-                    data = response.json()
-                    projects.extend(data['results'] or [])
-                    if not data['next']:
-                        break
-                    page += 1
-                wl_token = branch.repo_id.weblate_token
-                wl_url = branch.repo_id.weblate_url
+            projects = read_group(branch)
             for project in projects:
-                response = session.get('%s/projects/%s/components'
-                                       % (url, project['slug']))
-                response.raise_for_status()
-                components = response.json()
                 updated_branch = None
-                for component in components['results']:
+                for component in project['components']:
                     if ((updated_branch and
                             updated_branch == component['branch']) or
                             (component['branch'] != branch['branch_name']) or

--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -35,6 +35,9 @@ class RunbotBranch(models.Model):
 
     @api.model
     def cron_weblate(self):
+        projects = []
+        wl_token = ''
+        wl_url = ''
         for branch in self.search([('uses_weblate', '=', True)]):
             if (not branch.repo_id.weblate_token or
                     not branch.repo_id.weblate_url):
@@ -47,16 +50,20 @@ class RunbotBranch(models.Model):
                 'User-Agent': 'runbot_travis2docker',
                 'Authorization': 'Token %s' % branch.repo_id.weblate_token
             })
-            projects = []
-            page = 1
-            while True:
-                response = session.get('%s/projects/?page=%s' % (url, page))
-                response.raise_for_status()
-                data = response.json()
-                projects.extend(data['results'] or [])
-                if not data['next']:
-                    break
-                page += 1
+            if (wl_token != branch.repo_id.weblate_token or
+                    wl_url != branch.repo_id.weblate_url):
+                page = 1
+                while True:
+                    response = session.get('%s/projects/?page=%s' % (url,
+                                                                     page))
+                    response.raise_for_status()
+                    data = response.json()
+                    projects.extend(data['results'] or [])
+                    if not data['next']:
+                        break
+                    page += 1
+                wl_token = branch.repo_id.weblate_token
+                wl_url = branch.repo_id.weblate_url
             for project in projects:
                 response = session.get('%s/projects/%s/components'
                                        % (url, project['slug']))

--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -8,42 +8,7 @@ import re
 import subprocess
 import requests
 
-from openerp import fields, models, api
-
-
-def read_group(branch):
-    """Search all weblate API, project and component information.
-    Store into the local variable 'read_group.projects' to use as cache"""
-    if 'projects' not in read_group.__dict__:
-        read_group.projects = {}
-    url = branch.repo_id.weblate_url
-    key = '%s__%s' % (url, branch.repo_id.weblate_token)
-    page = 1
-    projects = []
-    session = requests.Session()
-    session.headers.update({
-        'Accept': 'application/json',
-        'User-Agent': 'runbot_travis2docker',
-        'Authorization': 'Token %s' % branch.repo_id.weblate_token
-    })
-    if key not in read_group.projects:
-        read_group.projects[key] = []
-        while True:
-            response = session.get('%s/projects/?page=%s' % (url, page))
-            response.raise_for_status()
-            data = response.json()
-            projects.extend(data['results'])
-            if not data['next']:
-                break
-            page += 1
-        for project in projects:
-            response = session.get('%s/projects/%s/components'
-                                   % (url, project['slug']))
-            response.raise_for_status()
-            data = response.json()
-            project['components'] = data['results']
-            read_group.projects[key].append(project)
-    return read_group.projects[key]
+from openerp import fields, models, api, tools
 
 
 class RunbotBranch(models.Model):
@@ -68,6 +33,36 @@ class RunbotBranch(models.Model):
                         dict(match.groupdict(), branch=branch['branch_name']))
             branch.name_weblate = name
 
+    @tools.ormcache('url', 'token')
+    def get_weblate_projects(self, url, token):
+        """Search all weblate API, project and component information.
+        Store into the local variable 'read_group.projects' to use as cache"""
+        projects = []
+        items = []
+        page = 1
+        session = requests.Session()
+        session.headers.update({
+            'Accept': 'application/json',
+            'User-Agent': 'runbot_travis2docker',
+            'Authorization': 'Token %s' % token
+        })
+        while True:
+            response = session.get('%s/projects/?page=%s' % (url, page))
+            response.raise_for_status()
+            data = response.json()
+            items.extend(data['results'])
+            if not data['next']:
+                break
+            page += 1
+        for project in items:
+            response = session.get('%s/projects/%s/components'
+                                   % (url, project['slug']))
+            response.raise_for_status()
+            data = response.json()
+            project['components'] = data['results']
+            projects.append(project)
+        return projects
+
     @api.model
     def cron_weblate(self):
         for branch in self.search([('uses_weblate', '=', True)]):
@@ -75,7 +70,8 @@ class RunbotBranch(models.Model):
                     not branch.repo_id.weblate_url):
                 continue
             cmd = ['git', '--git-dir=%s' % branch.repo_id.path]
-            projects = read_group(branch)
+            projects = self.get_weblate_projects(branch.repo_id.weblate_url,
+                                                 branch.repo_id.weblate_token)
             for project in projects:
                 updated_branch = None
                 for component in project['components']:
@@ -110,6 +106,7 @@ class RunbotBranch(models.Model):
                         continue
                     branch.force_weblate()
                     updated_branch = component['branch']
+        self.clear_caches()
 
     @api.multi
     def force_weblate(self):

--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -35,8 +35,9 @@ class RunbotBranch(models.Model):
 
     @tools.ormcache('url', 'token')
     def get_weblate_projects(self, url, token):
-        """Search all weblate API, project and component information.
-        Store into the local variable 'read_group.projects' to use as cache"""
+        """Find all projects and components that are on weblate url.
+        The cache is handled by @tools.ormcache annotation if the url and token
+        were already searched"""
         projects = []
         items = []
         page = 1
@@ -106,6 +107,8 @@ class RunbotBranch(models.Model):
                         continue
                     branch.force_weblate()
                     updated_branch = component['branch']
+        # The cache must be deleted to query the weblate API next time and get
+        # the latest changes
         self.clear_caches()
 
     @api.multi


### PR DESCRIPTION
Fix https://github.com/Vauxoo/runbot-addons/issues/117

When the url of weblate and the token is equal are stored the projects for used on another branch
This avoid many request to the same weblate API 