### PR TITLE
[FIX] runbot_travis2docker: Adding more validation to git diff

### DIFF
--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -99,8 +99,8 @@ class RunbotBranch(models.Model):
                         pass
                     subprocess.check_output(cmd + ['fetch', remote])
                     diff = subprocess.check_output(
-                        cmd + ['diff',
-                               'heads/%(branch)s..remotes/%(remote)s/%(branch)s'
+                        cmd + ['diff', 'heads/%(branch)s..'
+                               'remotes/%(remote)s/%(branch)s'
                                % {'branch': branch['branch_name'],
                                   'remote': remote}, '--stat'])
                     if not diff:

--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -100,7 +100,7 @@ class RunbotBranch(models.Model):
                     subprocess.check_output(cmd + ['fetch', remote])
                     diff = subprocess.check_output(
                         cmd + ['diff',
-                               '%(branch)s..%(remote)s/%(branch)s'
+                               'heads/%(branch)s..remotes/%(remote)s/%(branch)s'
                                % {'branch': branch['branch_name'],
                                   'remote': remote}, '--stat'])
                     if not diff:


### PR DESCRIPTION
I try `git diff origin/10.0..wl-github_com_JesusZapata_openacademy-project_10_0_/10.0 --stat` but this command fail

I try `git diff heads/10.0..remotes/wl-github_com_JesusZapata_openacademy-project_10_0/10.0 --stat` and this command it works well

![git-diff](https://user-images.githubusercontent.com/1387970/27063984-d111da92-4fc2-11e7-8449-0fd529210564.png)
