### PR TITLE
[FIX] runbot_travis2docker: Adding support to base languages

### DIFF
--- a/runbot_travis2docker/models/runbot_repo.py
+++ b/runbot_travis2docker/models/runbot_repo.py
@@ -31,6 +31,8 @@ class RunbotRepo(models.Model):
     @api.constrains('weblate_languages')
     def _check_weblate_languages(self):
         supported_langs = [item[0] for item in scan_languages()]
+        supported_langs.extend(set([lang.split('_')[0] for lang in
+                                    supported_langs]))
         for record in self.filtered('weblate_languages'):
             langs = record.weblate_languages.split(',')
             for lang in langs:


### PR DESCRIPTION
This PR adding support to base languages
For each language available get the prefix and group by this

Example: `es_ES > es`

![image](https://user-images.githubusercontent.com/1387970/27109417-c13f4524-5070-11e7-97cc-a66491f08cb3.png)
