### PR TITLE
[FIX] runbot_travis2docker: Fix the if bad condition

### DIFF
--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -91,7 +91,7 @@ class RunbotBranch(models.Model):
                         continue
                     component = [item for item in project['components']
                                  if item['git_export']]
-                    if len(component) > 1:
+                    if len(component) != 1:
                         continue
                     component = component[0]
                     remote = 'wl-%s-%s' % (project['slug'], component['slug'])


### PR DESCRIPTION
Change the condition `if len(component) > 1:` for `if len(component) != 1:`

The previus condition fail when the list of components is empty

![image](https://user-images.githubusercontent.com/1387970/28730306-9d07994a-739d-11e7-8de7-c129b937293b.png)
