### PR TITLE
[POC] runbot_send_email: Add wizard dialog for adding following

### DIFF
--- a/runbot_send_email/__openerp__.py
+++ b/runbot_send_email/__openerp__.py
@@ -18,10 +18,14 @@ email.",
     ],
     "data": [
         "views/runbot_send_email_view.xml",
+        "views/assets.xml",
         "data/runbot_send_email_data.xml",
     ],
     "demo": [
         "demo/ir_mail_server_demo.xml",
+    ],
+    'qweb': [
+        'static/src/xml/runbot_template.xml',
     ],
     "application": False,
     "installable": True,

--- a/runbot_send_email/__openerp__.py
+++ b/runbot_send_email/__openerp__.py
@@ -17,6 +17,8 @@ email.",
         "fetchmail",
     ],
     "data": [
+        'security/runbot_groups.xml',
+        'security/ir.model.access.csv',
         "views/runbot_send_email_view.xml",
         "views/assets.xml",
         "data/runbot_send_email_data.xml",

--- a/runbot_send_email/security/ir.model.access.csv
+++ b/runbot_send_email/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+
+access_add_followers_mail_followers,add_followers_mail_followers,mail.model_mail_followers,runbot_send_email.add_followers_group,1,0,0,0
+access_add_followers_res_partner,add_followers_res_partner,base.model_res_partner,runbot_send_email.add_followers_group,1,0,0,0

--- a/runbot_send_email/security/runbot_groups.xml
+++ b/runbot_send_email/security/runbot_groups.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+    <record id="add_followers_group" model="res.groups">
+        <field name="name">Add Followers Front-end</field>
+        <field name="comment">Users able to see the button add follers</field>
+        <field name="implied_ids" eval="[(4, ref('runbot.group_user'))]"/>
+    </record>
+</data>
+</openerp>

--- a/runbot_send_email/static/src/js/runbot.js
+++ b/runbot_send_email/static/src/js/runbot.js
@@ -1,0 +1,44 @@
+odoo.define('runbot.test', function (require) {
+    "use strict";
+
+var core = require('web.core');
+var base = require('web_editor.base');
+var Dialog = require('web.Dialog');
+var Model = require('web.Model');
+var Build = new Model('runbot.build');
+var _t = core._t;
+var Qweb = core.qweb;
+Qweb.add_template('/runbot_send_email/static/src/xml/runbot_template.xml');
+
+$("#lu_add_follower #follower-action-btn" ).on( "click", function(event) {
+    var self = this;
+    var build_id = $(this).data('runbot-build');
+    this.$content = $(Qweb.render('AddFollower'));
+    event.preventDefault;
+    Build.call("select_not_subscribe_partners", [build_id], {}).then(function(data) {
+        for(var i in data){
+            self.$content.find("#sel1").append('<option value='+data[i]['id']+'>'+data[i]['email']+'</option>');
+            }
+    });
+    var options = {
+                title: _t("<h3>Add Followers</h3>"),
+                size: 'medium',
+                buttons: [
+                    { text: _t("Save"), classes: 'btn-primary', close: true, click: function() {
+                      var partners = [];
+                      $("#sel1 option:selected").each(function(ind, element){
+                           partners.push(parseInt($(element).val()));
+                        });
+                      Build.call("add_followers", [[build_id], partners]);
+                     }
+                 },
+                    { text: _t("Close"), close: true }
+                ],
+                 $content: self.$content,
+             };
+     this.dialog = new Dialog(this, options).open();
+     this.dialog.$content.find("#sel1").select2({
+            maximumSelectionLength: 3
+         });
+    });
+});

--- a/runbot_send_email/static/src/xml/runbot_template.xml
+++ b/runbot_send_email/static/src/xml/runbot_template.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+    <t t-name="AddFollower">
+    <div class="form-group">
+          <label for="sel1"><h3>Select partner email</h3></label>
+            <select class="form-control" rows="100" multiple="multiple" size="1" id="sel1">
+            </select>
+    </div>
+    </t>
+</templates>

--- a/runbot_send_email/views/assets.xml
+++ b/runbot_send_email/views/assets.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+   <template id="runbot_assets_frontend" inherit_id="website.assets_frontend" name="runbot_t2d.assets.frontend">
+      <xpath expr="." position="inside">
+        <script type="text/javascript" src="/runbot_send_email/static/src/js/runbot.js"/>
+      </xpath>
+    </template>
+  </data>
+</openerp>

--- a/runbot_send_email/views/runbot_send_email_view.xml
+++ b/runbot_send_email/views/runbot_send_email_view.xml
@@ -15,5 +15,14 @@
                 </xpath>
             </field>
         </record>
+        
+    <template id="add_followings" inherit_id="runbot.build_button">
+       <xpath expr="//ul[@class='dropdown-menu']/li[6]" position="after">
+        <li id="lu_add_follower">
+           <a t-att-data-runbot-build="bu['id']" id="follower-action-btn">Add follower <i class="fa fa-user"/></a>
+        </li>
+      </xpath>
+   </template>
+    
     </data>
 </openerp>

--- a/runbot_send_email/views/runbot_send_email_view.xml
+++ b/runbot_send_email/views/runbot_send_email_view.xml
@@ -18,7 +18,7 @@
         
     <template id="add_followings" inherit_id="runbot.build_button">
        <xpath expr="//ul[@class='dropdown-menu']/li[6]" position="after">
-        <li id="lu_add_follower">
+        <li id="lu_add_follower"  groups="runbot_send_email.add_followers_group">
            <a t-att-data-runbot-build="bu['id']" id="follower-action-btn">Add follower <i class="fa fa-user"/></a>
         </li>
       </xpath>

--- a/runbot_travis2docker/views/runbot_repo_view.xml
+++ b/runbot_travis2docker/views/runbot_repo_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
   <data>
-
+    
     <record id="view_runbot_build_form" model="ir.ui.view">
       <field name="model">runbot.build</field>
       <field name="inherit_id" ref="runbot.view_build_form"/>


### PR DESCRIPTION
TODO

This PoC is based in issue https://github.com/Vauxoo/runbot-addons/issues/64
assistant dialog that allow add followers in builds of runbot since frontend. With this we can add follower in builds easily. 

The steps to use would be the following

1. Selected this option in this build
![list_drop_down](https://user-images.githubusercontent.com/16363083/28853737-a60020ba-7700-11e7-8eb2-d5f105d9b70e.png)

2. Show wizard dialog, select partner email,  press add for adding in list and after press button save for add follower in model build
![select_follower](https://user-images.githubusercontent.com/16363083/28853903-accb24b6-7701-11e7-8a71-d5e99342b36c.png)

3. It can be seen followers added in this build
![contacs](https://user-images.githubusercontent.com/16363083/28854458-347c0e72-7705-11e7-8de3-9b953fcb44b5.png)

![following_back_end](https://user-images.githubusercontent.com/16363083/28853951-0d4c7f38-7702-11e7-903b-90c9640a8945.png)

Here [video](https://www.youtube.com/watch?v=ghL4OL51G9Y) of  demonstrative 

@moylop260 @zaoral  what do you think about this ?