### PR TITLE
[FIX] runbot_send_email: fixed do not load partners in wizard front-end

### DIFF
--- a/runbot_send_email/static/src/js/runbot.js
+++ b/runbot_send_email/static/src/js/runbot.js
@@ -10,35 +10,62 @@ var _t = core._t;
 var Qweb = core.qweb;
 Qweb.add_template('/runbot_send_email/static/src/xml/runbot_template.xml');
 
+var _normalize_format_cache = {};
+ 
 $("#lu_add_follower #follower-action-btn" ).on( "click", function(event) {
+    
     var self = this;
     var build_id = $(this).data('runbot-build');
     this.$content = $(Qweb.render('AddFollower'));
+    this.wait = new Dialog(this, {title: _t("<h3>Wait loading data partners</h3>"),
+                                 size: 'medium',
+                                 buttons:[],
+                                 closeButton: false,
+                                 $content: $('<div><i class="fa fa-spinner fa-spin" style="font-size:24px"></i></div>')});
     event.preventDefault;
-    Build.call("select_not_subscribe_partners", [build_id], {}).then(function(data) {
-        for(var i in data){
-            self.$content.find("#sel1").append('<option value='+data[i]['id']+'>'+data[i]['email']+'</option>');
-            }
-    });
-    var options = {
-                title: _t("<h3>Add Followers</h3>"),
-                size: 'medium',
-                buttons: [
-                    { text: _t("Save"), classes: 'btn-primary', close: true, click: function() {
-                      var partners = [];
-                      $("#sel1 option:selected").each(function(ind, element){
-                           partners.push(parseInt($(element).val()));
-                        });
-                      Build.call("add_followers", [[build_id], partners]);
-                     }
-                 },
-                    { text: _t("Close"), close: true }
-                ],
-                 $content: self.$content,
+    this.addfollower = function(self, $content, build_id){
+        var options = {
+        title: _t("<h3>Add Followers</h3>"),
+        size: 'medium',
+        buttons: [
+                { text: _t("Save"), classes: 'btn-primary', close: true, click: function() {
+                var partners = [];
+                $("#sel1 option:selected").each(function(ind, element){
+                    partners.push(parseInt($(element).val()));
+                    var indexof = _normalize_format_cache[build_id].filter(function(elemt, index){
+                    if ($(elemt).val() == $(element).val()){
+                         delete _normalize_format_cache[build_id][index]
+                        }
+                    });
+                });
+                Build.call("add_followers", [[build_id], partners]);
+                }
+                },
+            { text: _t("Close"), close: true }
+            ],
+            $content: $content,
              };
-     this.dialog = new Dialog(this, options).open();
-     this.dialog.$content.find("#sel1").select2({
+            self.dialog = new Dialog(self, options).open();
+            self.dialog.$content.find("#sel1").select2({
             maximumSelectionLength: 3
-         });
-    });
+            });
+        };
+    if (_normalize_format_cache[build_id]) {
+         this.$content.find("#sel1").append(_normalize_format_cache[build_id]);
+         this.addfollower(this, this.$content, build_id);
+        } else {
+        this.wait.$modal.find('.close').remove();
+        this.wait.open();
+        _normalize_format_cache[build_id] = [];
+        Build.call("select_not_subscribe_partners", [build_id], {}).then(function(data) {
+        for(var i in data){
+            _normalize_format_cache[build_id].push('<option value='+data[i]['id']+'>'+data[i]['email']+'</option>');
+            }
+            self.$content.find("#sel1").append(_normalize_format_cache[build_id]);
+            self.wait.destroy();
+        }).done(function(){
+         self.addfollower(this, self.$content, build_id);
+        });
+   };
+  });
 });


### PR DESCRIPTION
When try add followers since front-end runbot this do not load partners. This not show  the list emails the partners

![runbot_no_found](https://user-images.githubusercontent.com/16363083/29050978-66314692-7bad-11e7-904b-6181db265e16.png)

but it is not a  problem of permissions because the user runbot  can see the view the contacts since backend

![menu_contacts](https://user-images.githubusercontent.com/16363083/29051014-ac0719bc-7bad-11e7-8506-e998d5c0f191.png)

Also can add followers since the widget in builds view

![add_followers_backend](https://user-images.githubusercontent.com/16363083/29051107-5a42e9f2-7bae-11e7-8fb7-9c636db15396.png)

[here](https://youtu.be/IFNtc1WnASY) video demonstration of this issue

This issue is because javascript it is a asynchronous language and the called for search the emails of the partners is executed after wizard was showed making that the data not load  on select of wizard


  

