### PR TITLE
[REF] runbot_build.py: Wait to run the command "docker start"

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -427,9 +427,11 @@ class RunbotBuild(models.Model):
         current_host = fqdn()
         for build in self.browse(cr, uid, ids, context=context):
             if not all([build.state == 'running', build.job == 'job_30_run',
+                        build.result in ['ok', 'warn'],
                         not build.docker_executed_commands,
                         build.repo_id.is_travis2docker_build]):
                 continue
+            time.sleep(20)
             build.write({'docker_executed_commands': True})
             run(['docker', 'exec', '-d', '--user', 'root',
                  build.docker_container, '/etc/init.d/ssh', 'start'])


### PR DESCRIPTION
This PR adding a sleep for `20` milliseconds to it allows to start the container

When the docker has many containers, the `docker start` command is late

With this change the trouble of the service sshd is not started is solved


