### PR TITLE
[FIX] runbot_travis2docker: In some case many components has a equal git_export

### DIFF
--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -124,8 +124,12 @@ class RunbotBranch(models.Model):
                         continue
                     component = [item for item in project['components']
                                  if item['git_export']]
-                    if len(component) != 1:
-                        continue
+                    if len(component) > 1:
+                        git_export = component[0]['git_export']
+                        different = [item for item in component if
+                                     item['git_export'] != git_export]
+                        if different:
+                            continue
                     component = component[0]
                     remote = 'wl-%s-%s' % (project['slug'], component['slug'])
                     url_repo = '/'.join([


### PR DESCRIPTION
In some case many components has a equal `git_export` url in that case is necessary to check if the git_export is different

For example

```
{
    "count": 24,
    "next": null,
    "previous": "http://weblate..com/api/projects/github_com_Project_demo_10_0/components/",
    "results": [
        {
            "name": "sale_coupon",
            "slug": "sale_coupon",
            "vcs": "git",
            "repo": "git@github.com:Project/demo.git",
            "git_export": "http://example.com/git/github_com_Project_demo_10_0/sale_coupon/",
            "branch": "10.0",
            "filemask": "sale_coupon/i18n/*.po",
            "template": "",
            "new_base": "",
            "file_format": "auto",
            "license": "",
            "license_url": "",
        },
        {
            "name": "website_user",
            "slug": "website_user",
            "vcs": "git",
            "repo": "git@github.com:Project/demo.git",
            "git_export": "http://example.com/git/github_com_Project_demo_10_0/website_user/",
            "branch": "10.0",
            "filemask": "website_user/i18n/*.po",
            "template": "",
            "new_base": "",
            "file_format": "auto",
            "license": "",
            "license_url": "",
        }
    ]
}
```
