### PR TITLE
[FIX] runbot_gitlab_minimal: hook - Use json hook because

### DIFF
--- a/runbot_gitlab_minimal/controllers/gitlab_ci_controller.py
+++ b/runbot_gitlab_minimal/controllers/gitlab_ci_controller.py
@@ -1,7 +1,6 @@
 # Copyright <2017> <Vauxoo info@vauxoo.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import json
 import logging
 
 from odoo import http
@@ -13,21 +12,24 @@ _logger = logging.getLogger(__name__)
 
 class RunbotCIController(RunbotHook):
 
-    @http.route(['/runbot/hook_gitlab/<int:repo_id>',
-                 '/runbot/hook_gitlab/org', '/runbot/hook/<int:repo_id>',
-                 '/runbot/hook/org'])
-    def hook(self, repo_id=None, **post):
-        data = (request.jsonrequest if hasattr(request, 'jsonrequest') else
-                json.loads(request.httprequest.stream.read()))
-        event = data['object_kind'] if 'object_kind' in data else None
-        repository = data['repository']
-        if repo_id is None:
-            if event in ['push', 'merge_request']:
-                repo_domain = ['|', ('name', '=', repository['url']),
-                               '|',
-                               ('name', '=', repository['homepage']),
-                               ('name', '=', repository['homepage'] + '.git')]
-                repo = request.env['runbot.repo'].sudo().search(repo_domain,
-                                                                limit=1)
-                repo_id = repo.id
-        return super(RunbotCIController, self).hook(repo_id, **post)
+    @http.route(
+        ['/runbot/hook_gitlab/<int:repo_id>', '/runbot/hook_gitlab/org'],
+        type='json', auth="public", website=True, csrf=False)
+    def hook_gitlab(self, repo_id=None, **post):
+        if repo_id:
+            return self.hook(repo_id, **post)
+        data = request.jsonrequest
+        event = data.get('object_kind')
+        if event in ['push', 'merge_request']:
+            # Compatible with gitlab version >=8.5 and <8.5
+            project = data.get('project') or data.get('repository')
+            ssh_url = project.get('git_ssh_url') or project.get('ssh_url')
+            http_url = project.get('git_http_url') or project.get('http_url')
+            repo_domain = ['|', '|', ('name', '=', ssh_url),
+                           ('name', '=', http_url),
+                           ('name', '=', http_url.rstrip('.git'))]
+            repo = request.env['runbot.repo'].sudo().search(repo_domain,
+                                                            limit=1)
+            if repo:
+                return self.hook(repo.id, **post)
+        return ""


### PR DESCRIPTION
gitlab uses json but runbot uses http since that github supports both
    (json and http)