### PR TITLE
[IMP] requirements.txt: Update travis2docker version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 matplotlib==2.2.2
-travis2docker==4.0.6
+travis2docker==4.0.7


### PR DESCRIPTION
This is to support the key `postgresql`, to define the PostgreSQL
version.

For more info, see:
https://github.com/Vauxoo/travis2docker/pull/117

[CI SKIP]