### PR TITLE
[FIX] runbot_travis2docker: Be more verbose when fetching SSH keys fails

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -189,8 +189,11 @@ class RunbotBuild(models.Model):
                 ssh_rsa = self.repo_id._github('/users/%(login)s/keys' %
                                                response[own_key])
                 keys += '\n' + '\n'.join(rsa['key'] for rsa in ssh_rsa)
-            except (TypeError, KeyError, requests.RequestException):
-                _logger.debug("Error fetching %s", own_key)
+            except (TypeError, KeyError, requests.RequestException) as err:
+                _logger.warning(
+                    "Error fetching %s (%s): %s",
+                    own_key, response and response.get(own_key), err)
+                _logger.warning("Response received: %s", response)
         return keys
 
     def _schedule(self):


### PR DESCRIPTION
Currently, if any error occurs when fetching SSH keys of the author and
committer, the printed message is bare and it's only visible in debug
level:

```
... DEBUG runbotdb odoo.addons.runbot_travis2docker.models.runbot_build:
Error fetching author
```
This commits makes this error more verbose and useful, and increases its
logging level to warning.

This is related to https://github.com/Vauxoo/runbot-addons/issues/173