### PR TITLE
[FIX] runbot_gitlab: Retrieve correctly SSH keys when under GitLab CI

### DIFF
--- a/runbot_gitlab/models/runbot_repo.py
+++ b/runbot_gitlab/models/runbot_repo.py
@@ -73,8 +73,8 @@ class RunbotRepo(models.Model):
         - Get user public keys
             input: URL_GITLAB/User.keys... instead of
                    URL_GITHUB/users/User/keys...
-            output: res['author'] = {'login': data['username']}
-                    res['commiter'] = {'login': data['username']}
+            output: res['author'] = data['username']
+                    res['committer'] = data['username']
         - Report statutes
             input: URL_GITLABL/... instead of URL_GITHUB/statuses/...
             output: N/A
@@ -108,10 +108,7 @@ class RunbotRepo(models.Model):
                             response = session.get(url)
                             response.raise_for_status()
                             data = response.json()
-                            json[own_key] = {
-                                'login':
-                                len(data) and data[0]['username'] or {}
-                            }
+                            json[own_key] = data and data[0]['username'] or ''
                 if is_url_keys:
                     json = [{'key': ssh_rsa} for ssh_rsa in json.split('\n')]
                 return json

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -185,14 +185,15 @@ class RunbotBuild(models.Model):
             return
         keys = ""
         for own_key in ['author', 'committer']:
+            login = response.get(own_key)
+            if not login:
+                continue
             try:
-                ssh_rsa = self.repo_id._github('/users/%(login)s/keys' %
-                                               response[own_key])
+                ssh_rsa = self.repo_id._github('/users/%(login)s/keys' % login)
                 keys += '\n' + '\n'.join(rsa['key'] for rsa in ssh_rsa)
-            except (TypeError, KeyError, requests.RequestException) as err:
+            except (TypeError, requests.RequestException) as err:
                 _logger.warning(
-                    "Error fetching %s (%s): %s",
-                    own_key, response and response.get(own_key), err)
+                    "Error fetching %s (%s): %s", own_key, login, err)
                 _logger.warning("Response received: %s", response)
         return keys
 


### PR DESCRIPTION
Currently, SSH keys are not retrieved correctly, due to a bad parsing of
usernames when retrieving commit information. The username is not a
string, but a dictionary `{'login': <user_name>}`.

This commit parses correctly usernames of committers and authors, so SSH
keys are retrieved correctly and SSH access may be granted.

This also causes empty authors to be skipped, they of course have
neither username nor SSH keys.