### PR TITLE
[FIX] runbot_gitlab: Retrieve correctly SSH keys when under GitLab CI

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -186,13 +186,14 @@ class RunbotBuild(models.Model):
         keys = ""
         for own_key in ['author', 'committer']:
             try:
-                ssh_rsa = self.repo_id._github('/users/%(login)s/keys' %
-                                               response[own_key])
+                login = response.get(own_key).get('login')
+                if login == '':
+                    continue
+                ssh_rsa = self.repo_id._github('/users/%s/keys' % login)
                 keys += '\n' + '\n'.join(rsa['key'] for rsa in ssh_rsa)
-            except (TypeError, KeyError, requests.RequestException) as err:
+            except (AttributeError, requests.RequestException) as err:
                 _logger.warning(
-                    "Error fetching %s (%s): %s",
-                    own_key, response and response.get(own_key), err)
+                    "Error fetching %s (%s): %s", own_key, login, err)
                 _logger.warning("Response received: %s", response)
         return keys
 


### PR DESCRIPTION
Currently, SSH keys are not retrieved correctly, due to a bad parsing of
the HTTP response. When keys are retrieved from GitLab, the response's
content is not a json, but a raw page; so it's raw bites, not str.

This commit parses correctly such responses, so SSH keys may be parsed
correctly and SSH access may be granted.

This also causes empty authors to be skipped, they of course have
neither username nor SSH keys, and retrieving them from GitLab would
cause issues.

Closes https://github.com/Vauxoo/runbot-addons/issues/173