### PR TITLE
[REF] runbot_travis2docker: Using github_token from image build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 matplotlib==2.2.2
-travis2docker==4.1.0
+travis2docker==4.2.0
 zc.recipe.egg


### PR DESCRIPTION
Since that clone process is runnig during docker build process and it is requiring github_token in order to apply patches of private repositories