### PR TITLE
[REF] runbot_travis2docker: Using t2d with deployv option

### DIFF
--- a/runbot_gitlab/controllers/gitlab_ci_controller.py
+++ b/runbot_gitlab/controllers/gitlab_ci_controller.py
@@ -20,7 +20,7 @@ class RunbotCIController(RunbotHook):
             return self.hook(repo_id, **post)
         data = request.jsonrequest
         event = data.get('object_kind')
-        if event in ['push', 'merge_request']:
+        if event in ['push', 'merge_request', 'build']:
             # Compatible with gitlab version >=8.5 and <8.5
             project = data.get('project') or data.get('repository')
             ssh_url = project.get('git_ssh_url') or project.get('ssh_url')
@@ -30,6 +30,14 @@ class RunbotCIController(RunbotHook):
                            ('name', '=', http_url.rstrip('.git'))]
             repo = request.env['runbot.repo'].sudo().search(repo_domain,
                                                             limit=1)
-            if repo:
+            if repo and event != 'build':
                 return self.hook(repo.id, **post)
+            if event == "build" and data["build_name"] == "build_deployv" and data["build_status"] == "success" and repo and repo.is_t2d_deployv:
+                build_domain = [("repo_id", "=", repo.id), ("name", "=", data["sha"])]
+                build = request.env["runbot.build"].sudo().search(build_domain, order='id DESC')
+                if build:
+                    build.write({"deployv_image_built": True})
+                    forced_builds = build._force("Image built so rebuild runbot job")
+                    if forced_builds:
+                        forced_builds.write({"deployv_image_built": True})
         return ""

--- a/runbot_gitlab/controllers/gitlab_ci_controller.py
+++ b/runbot_gitlab/controllers/gitlab_ci_controller.py
@@ -35,7 +35,7 @@ class RunbotCIController(RunbotHook):
             if (event == "build" and data["build_name"] in ("build_deployv", "build_docker") and
                 data["build_status"] == "success" and repo and repo.is_t2d_deployv):
                 build_domain = [("repo_id", "=", repo.id), ("name", "=", data["sha"])]
-                build = request.env["runbot.build"].sudo().search(build_domain, order='id DESC')
+                build = request.env["runbot.build"].sudo().search(build_domain, order='id DESC', limit=1)
                 if build:
                     build.write({"deployv_image_built": True})
                     forced_builds = build._force("Image built so rebuild runbot job")

--- a/runbot_gitlab/controllers/gitlab_ci_controller.py
+++ b/runbot_gitlab/controllers/gitlab_ci_controller.py
@@ -25,6 +25,11 @@ class RunbotCIController(RunbotHook):
             project = data.get('project') or data.get('repository')
             ssh_url = project.get('git_ssh_url') or project.get('ssh_url')
             http_url = project.get('git_http_url') or project.get('http_url')
+            if event == "build":
+                # The "jobs" webhook only are triggered from from dev projects
+                # but we need to match with stable one
+                ssh_url = ssh_url.replace("-dev/", "/")
+                http_url = http_url.replace("-dev/", "/")
             repo_domain = ['|', '|', ('name', '=', ssh_url),
                            ('name', '=', http_url),
                            ('name', '=', http_url.rstrip('.git'))]

--- a/runbot_gitlab/controllers/gitlab_ci_controller.py
+++ b/runbot_gitlab/controllers/gitlab_ci_controller.py
@@ -32,7 +32,8 @@ class RunbotCIController(RunbotHook):
                                                             limit=1)
             if repo and event != 'build':
                 return self.hook(repo.id, **post)
-            if event == "build" and data["build_name"] == "build_deployv" and data["build_status"] == "success" and repo and repo.is_t2d_deployv:
+            if (event == "build" and data["build_name"] in ("build_deployv", "build_docker") and
+                data["build_status"] == "success" and repo and repo.is_t2d_deployv):
                 build_domain = [("repo_id", "=", repo.id), ("name", "=", data["sha"])]
                 build = request.env["runbot.build"].sudo().search(build_domain, order='id DESC')
                 if build:

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -40,6 +40,7 @@ class RunbotBuild(models.Model):
     docker_executed_commands = fields.Boolean(
         help='True: Executed "docker exec CONTAINER_BUILD custom_commands"',
         readonly=True, copy=False)
+    deployv_image_built = fields.Boolean('DeployV image was already built?')
 
     def _get_docker_image(self):
         self.ensure_one()
@@ -140,11 +141,14 @@ class RunbotBuild(models.Model):
 
     def _checkout(self):
         builds = self.filtered('branch_id.repo_id.is_travis2docker_build')
+        builds_waiting_image = builds.filtered(lambda b: b.repo_id.is_t2d_deployv and not b.deployv_image_built)
         super(RunbotBuild, self - builds)._checkout()
         to_be_skipped_ids = builds
-        for build in builds:
-            branch_short_name = build.branch_id.name.replace(
-                'refs/heads/', '', 1).replace('refs/pull/', 'pull/', 1)
+        for build in (builds - builds_waiting_image):
+            branch_short_name = (
+                build.branch_id.name.replace('refs/heads/', '', 1).replace('refs/pull/', 'pull/', 1)
+                if not build.repo_id.is_t2d_deployv else build.name
+            )
             t2d_path = os.path.join(build.repo_id._root(), 'travis2docker')
             repo_name = build.repo_id.name
             if not any((repo_name.startswith('https://'),
@@ -156,32 +160,40 @@ class RunbotBuild(models.Model):
                 'travisfile2dockerfile', repo_name,
                 branch_short_name, '--root-path=' + t2d_path,
                 '--exclude-after-success',
-                '--docker-image=%s' % build.repo_id.travis2docker_image,
                 # Avoid corruption of postgresql
                 '--runs-at-the-end-script=pg_isready -q && '
                 '/etc/init.d/postgresql stop'
             ]
+            if build.repo_id.travis2docker_image and not build.repo_id.is_t2d_deployv:
+                sys.argv.append('--docker-image=%s' % build.repo_id.travis2docker_image)
+            if build.repo_id.is_t2d_deployv:
+                sys.argv.append('--deployv')
             if build._get_github_token():
                 sys.argv.append("--build-env-args=GITHUB_TOKEN")
             try:
-                path_scripts = t2d()
+                _logger.warning(' '.join(sys.argv))
+                path_scripts = t2d(return_result=True)
             except BaseException:  # TODO: Add custom exception to t2d
                 path_scripts = []
             for path_script in path_scripts:
                 df_content = open(os.path.join(
                     path_script, 'Dockerfile')).read()
                 if ' TESTS=1' in df_content or ' TESTS="1"' in df_content or \
-                        " TESTS='1'" in df_content:
+                        " TESTS='1'" in df_content or build.repo_id.is_t2d_deployv:
                     build.dockerfile_path = path_script
                     build.docker_image = build._get_docker_image()
                     build.docker_container = build._get_docker_container()
                     if build in to_be_skipped_ids:
                         to_be_skipped_ids -= build
                     break
-        if to_be_skipped_ids:
+        if to_be_skipped_ids - builds_waiting_image:
             _logger.info('Dockerfile without TESTS=1 env. '
                          'Skipping builds %s', to_be_skipped_ids.ids)
             to_be_skipped_ids._skip()
+        if builds_waiting_image:
+            _logger.info('Waiting for deployv image built in quay.io '
+                         'Skipping builds %s', builds_waiting_image.ids)
+            builds_waiting_image._skip()
 
     def _local_cleanup(self):
         builds = self.filtered('branch_id.repo_id.is_travis2docker_build')
@@ -235,6 +247,11 @@ class RunbotBuild(models.Model):
                     build.docker_container,
                     "bash", "-c", "echo '%(keys)s' | tee -a '%(dir)s'" % dict(
                         keys=ssh_keys, dir="/home/odoo/.ssh/authorized_keys"),
+                ])
+            if build.repo_id.is_t2d_deployv:
+                # Deployv use .ssh as volume it needs to change the owner to be able to connect
+                subprocess.call([
+                    "docker", "exec", "-d", "--user", "root", build.docker_container, "chown", "-R", "odoo:odoo", "/home/odoo/.ssh",
                 ])
             RunbotBuild._open_url(build.port, build.host)
         return res

--- a/runbot_travis2docker/models/runbot_repo.py
+++ b/runbot_travis2docker/models/runbot_repo.py
@@ -10,6 +10,7 @@ class RunbotRepo(models.Model):
     _inherit = "runbot.repo"
 
     is_travis2docker_build = fields.Boolean('Travis to docker build')
+    is_t2d_deployv = fields.Boolean('Use t2d --deployv')
     travis2docker_test_disable = fields.Boolean('Test Disable?')
     travis2docker_image = fields.Char(
         default=lambda s: s._default_travis2docker_image(),

--- a/runbot_travis2docker/views/runbot_repo_view.xml
+++ b/runbot_travis2docker/views/runbot_repo_view.xml
@@ -8,6 +8,7 @@
         <xpath expr="//group[@name='repo_group']" position="after">
           <group name="travis2docker">
             <field name="is_travis2docker_build"/>
+            <field name="is_t2d_deployv"/>
             <field name="travis2docker_test_disable" attrs="{'invisible': [('is_travis2docker_build', '=', False)]}"/>
             <field name="travis2docker_image"
                    attrs="{'invisible': [('is_travis2docker_build', '=', False)],


### PR DESCRIPTION
Requires the following patch:

```patch
index c168749..12826c3 100644
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -292,6 +292,7 @@ class runbot_build(models.Model):
                     'committer_email': build.committer_email,
                     'subject': build.subject,
                     'modules': build.modules,
+                    'deployv_image_built': build.deployv_image_built,
                     'build_type': 'rebuild'
                 })
                 build = new_build

```


It requires to add a new webhooks to "-dev" project to trigger jobs (Not working for stable project)


TODO: Add new field to runbot.build view