### PR TITLE
[REF] runbot_travis2docker: Fix error for >=15.0 instances using 22 instead of 8072

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -285,7 +285,8 @@ class RunbotBuild(models.Model):
             '-e', 'TEST_ENABLE=%d' % (
                 not self.repo_id.travis2docker_test_disable),
             '-p', '127.0.0.1:%d:%d' % (self.port, 8069),
-            '-p', '%d:%d' % (self.port + 1, 22),
+            '-p', '127.0.0.1:%d:%d' % (self.port + 1, 22),
+            '-p', '127.0.0.1:%d:%d' % (self.port + 2, 8072),
         ] + pr_cmd_env + wl_cmd_env
         cmd.extend(['--name=' + self.docker_container, '-t',
                     self.docker_image])


### PR DESCRIPTION
It requires the following patch:

    diff --git a/runbot/templates/nginx.xml b/runbot/templates/nginx.xml
    index d4f41f7..e74ecc3 100644
    --- a/runbot/templates/nginx.xml
    +++ b/runbot/templates/nginx.xml
    @@ -10,7 +10,7 @@ http {
    include /etc/nginx/mime.types;
    server_names_hash_max_size 512;
    server_names_hash_bucket_size 256;
    -client_max_body_size 10M;
    +client_max_body_size 64M;
    index index.html;
    log_format full '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent '
    @@ -25,31 +25,43 @@ autoindex on;
    gzip on;
    gzip_types text/css text/plain application/xml application/json application/javascript;

    +map $http_x_forwarded_proto $real_scheme {
    +  default $http_x_forwarded_proto;
    +  ''      $scheme;
    +}
    +
    proxy_temp_path <t t-esc="nginx_dir"/>;
    proxy_read_timeout 600;
    proxy_connect_timeout 600;
    proxy_set_header X-Forwarded-Host $host;
    +proxy_set_header X-Forwarded-Proto $real_scheme;
    proxy_set_header Host $host;

    server {
        listen 8080 default;
    -    location / { proxy_pass http://127.0.0.1:<t/ t-esc="port"/>; }
    -    location /longpolling/im/poll { return 404; }
    -    location /longpolling/poll { return 404; }
        location /runbot/static/ {
            alias <t t-esc="runbot_static"/>;
            autoindex off;
    -       location ~ /runbot/static/build/[^/]+/logs/ {
    +       location ~ /runbot/static/build/[^/]+/(logs|tests)/ {
            autoindex on;
            }
        }
    }
    +
    <t t-foreach="builds" t-as="build">
    server {
        listen 8080;
    -    server_name ~^<t t-raw="re_escape(build.dest)"/>(-[a-z0-9]+)?\.<t t-raw="re_escape(fqdn)"/>$;
    +    server_name ~^<t t-raw="re_escape(build.dest)"/>(-[a-z0-9_]+)?\.<t t-raw="re_escape(fqdn)"/>$;
        location / { proxy_pass http://127.0.0.1:<t/ t-esc="build.port"/>; }
    -    location /longpolling { proxy_pass http://127.0.0.1:<t/ t-esc="build.port + 1"/>; }
    +    location /longpolling { proxy_pass http://127.0.0.1:<t/ t-esc="build.port + 2"/>; }
    +    location /websocket {
    +      proxy_pass http://127.0.0.1:<t/ t-esc="build.port + 2"/>;
    +      proxy_set_header X-Forwarded-Host $host;
    +      proxy_set_header X-Forwarded-Proto $real_scheme;
    +      proxy_set_header Host $host;
    +      proxy_set_header Upgrade $http_upgrade;
    +      proxy_set_header Connection "Upgrade";
    +    }
    }
    </t>
    server {
