### PR TITLE
DRAFT: [ADD] docker setup to run locally

### DIFF
--- a/.docker/compose.yaml.template
+++ b/.docker/compose.yaml.template
@@ -1,0 +1,28 @@
+name: vxrun
+services:
+  odoo:
+    build: odoo
+    depends_on:
+      - db
+    group_add:
+      - "$DOCKER_GID"
+    ports:
+      - "8069"
+      - "8072"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  db:
+    image: postgres:13
+    environment:
+      - POSTGRES_USER=odoo
+      - POSTGRES_PASSWORD=odoo
+  proxy:
+    image: nginx:1.23
+    depends_on:
+      - odoo
+    environment:
+      - NGINX_SERVER_NAME=$RUNBOT_NAME
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx:/etc/nginx/templates

--- a/.docker/nginx/default.conf.template
+++ b/.docker/nginx/default.conf.template
@@ -1,0 +1,28 @@
+upstream runbot {
+    server odoo:8069 weight=1 max_fails=3 fail_timeout=200m;
+}
+
+upstream runbotpoll {
+    server odoo:8072 weight=1 max_fails=3 fail_timeout=200m;
+}
+
+server {
+    listen 80;
+    server_name *.${NGINX_SERVER_NAME};
+
+    proxy_send_timeout 200m;
+    proxy_read_timeout 200m;
+    proxy_connect_timeout 200m;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
+
+    location / {
+        proxy_pass http://runbot;
+    }
+
+    location /longpolling {
+        proxy_pass http://runbotpoll;
+    }
+}

--- a/.docker/odoo/.openerp_serverrc
+++ b/.docker/odoo/.openerp_serverrc
@@ -1,0 +1,13 @@
+[options]
+addons_path=${HOME}/instance/dependencies/runbot-addons,
+    ${HOME}/instance/dependencies/odoo-extra,
+    ${HOME}/instance/odoo/addons,
+    ${HOME}/instance/odoo/odoo/addons
+db_host = db
+db_user = odoo
+db_password = odoo
+db_name = runbot
+dbfilter = runbot
+workers = 2
+logfile = /home/runbot/odoo.log
+log-level = warn

--- a/.docker/odoo/Dockerfile
+++ b/.docker/odoo/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:18.04
+
+RUN apt update; \
+    DEBIAN_FRONTEND=noninteractive apt -y --no-install-recommends install \
+      ca-certificates curl gnupg lsb-release python3-pip python3-dev python3-lxml libsasl2-dev libldap2-dev ssh \
+      libjpeg-dev libpq-dev libssl1.0-dev build-essential python3-matplotlib nodejs-dev node-gyp npm git locales;  \
+    locale-gen en_US.UTF-8; \
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg; \
+    echo  \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | \
+      tee /etc/apt/sources.list.d/docker.list > /dev/null; \
+    apt update; \
+    apt -y --no-install-recommends install docker-ce; \
+    useradd -m runbot;
+
+USER runbot
+RUN mkdir -p ~/instance; \
+    git clone -b 11.0 --depth=1  https://github.com/Vauxoo/runbot-addons.git ~/instance/dependencies/runbot-addons; \
+    git clone -b 11.0-vauxoo --depth=1 https://github.com/Vauxoo/runbot.git ~/instance/dependencies/odoo-extra; \
+    git clone -b 11.0 --depth=1 https://github.com/odoo/odoo.git ~/instance/odoo; \
+    git config --global user.name runbot; \
+    git config --global user.email runbot@vauxoo.com; \
+    mkdir ${HOME}/.ssh; \
+    ssh-keyscan github.com >> ${HOME}/.ssh/known_hosts; \
+    ssh-keyscan launchpad.net >> ${HOME}/.ssh/known_hosts; \
+    ssh-keyscan bitbucket.org >> ${HOME}/.ssh/known_hosts; \
+    ssh-keyscan gitlab.com >> ${HOME}/.ssh/known_hosts; \
+    ssh-keyscan git.vauxoo.com >> ${HOME}/.ssh/known_hosts;
+
+USER root
+RUN sed -i '/lxml/d' /home/runbot/instance/odoo/requirements.txt; \
+    pip3 install setuptools==57.5.0 wheel; \
+    pip3 install -r /home/runbot/instance/odoo/requirements.txt; \
+    pip3 install -U travis2docker simplejson; \
+    npm install -g less@3.0.4 less-plugin-clean-css;
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+USER runbot
+COPY ./entrypoint.sh /
+COPY ./wait-for-sql /usr/local/bin/
+COPY --chown=runbot:runbot ./.openerp_serverrc $HOME/
+
+ENV ODOO_RC=$HOME/.openerp_serverrc
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["runbot"]

--- a/.docker/odoo/Dockerfile
+++ b/.docker/odoo/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 RUN apt update; \
     DEBIAN_FRONTEND=noninteractive apt -y --no-install-recommends install \
       ca-certificates curl gnupg lsb-release python3-pip python3-dev python3-lxml libsasl2-dev libldap2-dev ssh \
-      libjpeg-dev libpq-dev libssl1.0-dev build-essential python3-matplotlib nodejs-dev node-gyp npm git locales;  \
+      libjpeg-dev libpq-dev libssl1.0-dev build-essential python3-matplotlib nodejs-dev node-gyp npm nginx git locales;  \
     locale-gen en_US.UTF-8; \
     mkdir -p /etc/apt/keyrings; \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg; \

--- a/.docker/odoo/Dockerfile
+++ b/.docker/odoo/Dockerfile
@@ -12,7 +12,9 @@ RUN apt update; \
       tee /etc/apt/sources.list.d/docker.list > /dev/null; \
     apt update; \
     apt -y --no-install-recommends install docker-ce; \
-    useradd -m runbot;
+    useradd -m runbot; \
+    chown -R runbot:runbot /var/lib/nginx; \
+    chown -R runbot:runbot /var/log/nginx;
 
 USER runbot
 RUN mkdir -p ~/instance; \

--- a/.docker/odoo/entrypoint.sh
+++ b/.docker/odoo/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "$1" == "runbot" ]] ; then
+  shift
+  wait-for-sql
+  exec ~/instance/odoo/odoo-bin -i runbot_travis2docker --without-demo=all "$@"
+else
+  exec "$@"
+fi

--- a/.docker/odoo/wait-for-sql
+++ b/.docker/odoo/wait-for-sql
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import argparse
+import configparser
+import getpass
+import os
+import psycopg2
+import sys
+import time
+
+
+if __name__ == '__main__':
+    if not os.environ.get("ODOO_RC"):
+        print("Missing configuration file. Unable to find connection settings.")
+        sys.exit(1)
+
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--timeout', type=int, default=30)
+    args = arg_parser.parse_args()
+
+    config = configparser.ConfigParser()
+    config.read(os.environ.get("ODOO_RC"))
+    config = config["options"]
+
+    db_user = config.get("db_user", getpass.getuser())
+    db_host = config.get("db_host")
+    db_port = config.getint("db_port", 5432)
+    db_password = config.get("db_password")
+
+    start_time = time.time()
+    while (time.time() - start_time) < args.timeout:
+        try:
+            conn = psycopg2.connect(user=db_user, host=db_host, port=db_port, password=db_password, dbname='postgres')
+            error = ''
+            break
+        except psycopg2.OperationalError as e:
+            error = e
+        else:
+            conn.close()
+        time.sleep(1)
+
+    if error:
+        print("Database connection failure: %s" % error, file=sys.stderr)
+        sys.exit(1)

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 # Backup files
 *~
 *.swp
+
+# Generated host specific compose file
+.docker/compose.yaml

--- a/container.py
+++ b/container.py
@@ -33,7 +33,8 @@ def main():
     )
 
     print(
-        "Success. You can now start your Runbot instance with 'docker compose -f .docker/compose.yaml up'. "
+        "Success. You can now start your Runbot instance with 'docker compose -f .docker/compose.yaml up'."
+        "\nTODO: Run the following command in the runbot container: 'chown runbot:runbot /var/run/docker.sock && docker login quay.io'"
     )
 
 

--- a/container.py
+++ b/container.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from grp import getgrnam
+from os import getcwd
+from os.path import join
+from shutil import which
+from subprocess import run
+
+
+def main():
+    parser = ArgumentParser("Bootstrap a Runbot Docker Compose setup")
+    parser.add_argument(
+        "-d",
+        "--domain",
+        default="runbot.vauxoo.test",
+        type=str,
+        help="Domain name for the Runbot instance",
+    )
+    args = parser.parse_args()
+
+    if not which("envsubst"):
+        raise SystemExit("Required executable 'envsubst' not found in the system")
+
+    try:
+        docker_grp = getgrnam("docker")
+    except KeyError:
+        raise SystemExit("Required group 'docker' not found in the system")
+
+    run(
+        f"DOCKER_GID={docker_grp.gr_gid} RUNBOT_NAME={args.domain} envsubst < compose.yaml.template > compose.yaml",
+        cwd=join(getcwd(), ".docker"),
+        shell=True,
+    )
+
+    print(
+        "Success. You can now start your Runbot instance with 'docker compose -f .docker/compose.yaml up'. "
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Related to #193. This commit adds the files required to automatically create a local runbot instance with the command "docker compose up". The end result is developers having easy access to on-demand local instances to speed up the development process.

Based on https://gist.github.com/moylop260/c1d2fe1ccc9c009e6d8d