### PR TITLE
[REF] runbot_gitlab: Support dev projects with same org

### DIFF
--- a/runbot_gitlab/controllers/gitlab_ci_controller.py
+++ b/runbot_gitlab/controllers/gitlab_ci_controller.py
@@ -36,8 +36,8 @@ class RunbotCIController(RunbotHook):
                 data["build_status"] == "success"):
                 # The "jobs" webhook only are triggered from from dev projects
                 # but we need to match with stable one
-                ssh_url_stb = ssh_url.replace("-dev/", "/")
-                http_url_stb = http_url.replace("-dev/", "/")
+                ssh_url_stb = ssh_url.replace("-dev", "/")
+                http_url_stb = http_url.replace("-dev", "/")
                 repo_domain = [
                     '|', '|', ('name', '=', ssh_url_stb),
                     ('name', '=', http_url_stb),


### PR DESCRIPTION
You can prefer to use only one organization for stable and dev repositories

I mean, the code only supported the following structure

    stable: git_url/organization/project
    dev: git_url/organization-dev/project

Now, it is compatible with

    stable: git_url/organization/project
    dev: git_url/organization/project-dev

It is useful when you are paying a service by organization

so your dev forks could be better to use the same organization in order to save extra costs because useing 2 organizations