### PR TITLE
[IMP] runbot_travis2docker: Pregenerate assets calling _pregenerate_assets_bundles method

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -266,6 +266,17 @@ class RunbotBuild(models.Model):
                         keys=ssh_keys, dir="/home/odoo/.ssh/authorized_keys"),
                 ])
             RunbotBuild._open_url(build.port, build.host)
+            try:
+                pregenerate_assets_cmd = (
+                    "echo \"env['ir.qweb']._pregenerate_assets_bundles(); env.cr.commit()\" | "
+                    "python3 /home/odoo/instance/odoo/odoo-bin shell -d odoo --stop-after-init"
+                )
+                pregenerate_assets_exec_cmd = ['docker', 'exec', '--user', 'odoo', build.docker_container, 'bash', '-c', pregenerate_assets_cmd]
+                result = subprocess.run(pregenerate_assets_exec_cmd, capture_output=True, text=True, check=False, timeout=360)
+                _logger.info("Result for %s _pregenerate_assets_bundles %s", build.docker_container, result)
+            except Exception as e:
+                _logger.error("Failed _pregenerate_assets_bundles assets for %s: %s", build.docker_container, e)
+
         return res
 
     def _get_docker_run_cmd(self):


### PR DESCRIPTION
Pregenerate JS/CSS assets bundles inside the container immediately after startup.

Without this pregeneration, the first request (e.g. login) incurs a ~74 seconds delay while compiling and minifying assets bundles.

The execution runs `_pregenerate_assets_bundles` via Odoo shell and is wrapped in a try-except block with a 360s timeout to prevent crashing the scheduler in case of failure.


Running the first time this method the output is:
 - `2026-06-20 19:56:26,884 467 INFO odoo odoo.addons.base.models.ir_qweb: CSS Assets bundles generated in 74 seconds`

Notice 74 seconds delay

The second time calling the same method the  result is:
 - `2026-06-20 20:27:57,295 702 INFO odoo odoo.addons.base.models.ir_qweb: CSS Assets bundles generated in 2 seconds`

Only 2 seconds

The whole log file of the first time:
[odoo_runbot_pregenerate.log.zip](https://github.com/user-attachments/files/29166909/odoo_runbot_pregenerate.log.zip)


py-spy /web/login
<img width="1200" height="890" alt="odoo_runbot_login" src="https://github.com/user-attachments/assets/76bd0a6a-a418-4a66-8576-bf72ebf28217" />
