### PR TITLE
[REF] runbot_travis2docker: Warm up cache for dark theme

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -403,6 +403,9 @@ class RunbotBuild(models.Model):
                     params={"lang": lang},
                     timeout=120,
                 )
+            # Odoo 17.0+ has dark theme based on system but by default get light one
+            # manually called to warn up the cache with dark too
+            s.get(f"{url}/web/assets/any/web.assets_web_dark.min.css", timeout=120)
             _logger.info("Warmup completed for domain %s", self.domain)
         except Exception as error:
             _logger.warning("Warmup failed for domain %s: %s", self.domain, error)

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -269,6 +269,12 @@ class RunbotBuild(models.Model):
                     "bash", "-c", "echo '%(keys)s' | tee -a '%(dir)s'" % dict(
                         keys=ssh_keys, dir="/home/odoo/.ssh/authorized_keys"),
                 ])
+            # Deactivate all ir_cron
+            subprocess.call([
+                'docker', 'exec', '-d', '--user', 'odoo',
+                build.docker_container,
+                'bash', '-c', 'psql odoo -c "UPDATE ir_cron SET active=False"',
+            ])
             build._open_url()
         return res
 


### PR DESCRIPTION
Continuation from last commit in order to get the dark theme even if the light one is the default